### PR TITLE
fix bug on issue#4

### DIFF
--- a/src/LogStatGen.java
+++ b/src/LogStatGen.java
@@ -174,8 +174,11 @@ public class LogStatGen {
     public  static void createCSVFile(List<String[]> dataList, String finalPath) {
         try {
             File file = new File(finalPath);
-            if (!file.getParentFile().exists()) { //
-                file.getParentFile().mkdirs();
+            File parent = file.getParentFile();
+            if(parent == null)
+                parent = new File("./");
+            if (!parent.exists()) { //
+                parent.mkdirs();
             }
             if (file.exists()) { //
                 file.delete();


### PR DESCRIPTION
fix bug on issue#4. I took a look into the source code of the logStatGen.java and fix bug on createCSV method in the code, letting the parent directory of the given 'o' argument to be the current directory if it is without a parent directory, for example,  given 'output.txt', it is regarded as './output.txt'.